### PR TITLE
Make XENGPUMiner work on macOS with OpenCL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,11 @@ if(NOT NO_CUDA)
     find_package(CUDA)
 endif()
 
+if (APPLE)
+    find_package(OpenCL REQUIRED)
+    include_directories( ${OPENCL_INCLUDE_DIR})
+endif()
+
 if(CUDA_FOUND)
     message("INFO: Using CUDA version ${CUDA_VERSION}")
     add_definitions(-DHAVE_CUDA=1)
@@ -90,9 +95,17 @@ target_include_directories(argon2-opencl PRIVATE
 gpuMiner/include/argon2-opencl
 gpuMiner/lib/argon2-opencl
 )
-target_link_libraries(argon2-opencl
-    argon2-gpu-common -lOpenCL
-)
+
+if (UNIX AND NOT APPLE)
+    target_link_libraries(argon2-opencl
+        argon2-gpu-common -lOpenCL
+    )
+endif()
+if (APPLE)
+    target_link_libraries(argon2-opencl
+        argon2-gpu-common "-framework OpenCL"
+    )
+endif()
 
 add_executable(xengpuminer
 gpuMiner/src/argon2-gpu-bench/cpuexecutive.cpp

--- a/gpuMiner/ext/argon2/CMakeLists.txt
+++ b/gpuMiner/ext/argon2/CMakeLists.txt
@@ -109,7 +109,12 @@ target_link_libraries(argon2-genkat argon2)
 
 add_executable(argon2-bench2 src/bench2.c)
 target_include_directories(argon2-bench2 PRIVATE src)
-target_link_libraries(argon2-bench2 argon2 -lrt)
+if (UNIX AND NOT APPLE)
+    target_link_libraries(argon2-bench2 argon2 -lrt)
+endif()
+if (APPLE)
+    target_link_libraries(argon2-bench2 argon2)
+endif()
 
 add_executable(argon2-test tests/test.c)
 target_include_directories(argon2-test PRIVATE tests)

--- a/gpuMiner/include/argon2-gpu-common/argon2params.h
+++ b/gpuMiner/include/argon2-gpu-common/argon2params.h
@@ -3,6 +3,10 @@
 
 #include <cstdint>
 
+#if defined(__APPLE__) || defined(__MACOSX)
+    #include <cstddef>
+#endif
+
 #include "argon2-common.h"
 
 namespace argon2 {

--- a/gpuMiner/include/argon2-opencl/opencl.h
+++ b/gpuMiner/include/argon2-opencl/opencl.h
@@ -21,7 +21,11 @@
 /* Some compatibility hacks: */
 #define CL_USE_DEPRECATED_OPENCL_1_1_APIS
 #define CL_USE_DEPRECATED_OPENCL_1_2_APIS
+#if defined(__APPLE__) || defined(__MACOSX)
+#include <OpenCL/cl.h>
+#else
 #include <CL/cl.h>
+#endif
 #undef CL_VERSION_2_0
 
 /* Throw exceptions on errors: */

--- a/gpuMiner/lib/argon2-gpu-common/blake2b.h
+++ b/gpuMiner/lib/argon2-gpu-common/blake2b.h
@@ -3,6 +3,10 @@
 
 #include <cstdint>
 
+#if defined(__APPLE__) || defined(__MACOSX)
+    #include <cstddef>
+#endif
+
 namespace argon2 {
 
 class Blake2b


### PR DESCRIPTION
Added some includes and updates to make files to allow build on macOS (tested on 13.5.x).